### PR TITLE
Fix largest Ayah number typo in API response

### DIFF
--- a/src/Quran/Api/AyatResponse.php
+++ b/src/Quran/Api/AyatResponse.php
@@ -118,7 +118,7 @@ class AyatResponse extends QuranResponse
         if ($number === null) {
             $this->setCode(400);
             $this->setStatus('Bad Request');
-            $this->response = 'Please specify an Ayah number (1 to 6326) or a reference in the format Surah:Ayat (2:255).';
+            $this->response = 'Please specify an Ayah number (1 to 6236) or a reference in the format Surah:Ayat (2:255).';
 
             return $number;
         }
@@ -126,10 +126,10 @@ class AyatResponse extends QuranResponse
         if (is_array($number)) {
             return $this->loadByReference($number[0], $number[1]);
         } else {
-            if ($number < 1 || $number > 6326) {
+            if ($number < 1 || $number > 6236) {
                 $this->setCode(400);
                 $this->setStatus('Bad Request');
-                $this->response = 'Please specify an Ayah number (1 to 6326).';
+                $this->response = 'Please specify an Ayah number (1 to 6236).';
             } else {
                 return $this->loadByNumber($number);
             }
@@ -160,7 +160,7 @@ class AyatResponse extends QuranResponse
         } else {
             $this->setCode(400);
             $this->setStatus('Bad Request');
-            $this->response = 'Please specify an Ayah number (1 to 6326)';
+            $this->response = 'Please specify an Ayah number (1 to 6236)';
         }
     }
 


### PR DESCRIPTION
The largest Ayah is 6236. This file considers the largest Ayah to be 6326. API returns bad request correctly currently but the response data contained a reference to the typo as well.