### PR TITLE
Surahs response type

### DIFF
--- a/src/Quran/Api/JuzResponse.php
+++ b/src/Quran/Api/JuzResponse.php
@@ -111,6 +111,9 @@ class JuzResponse extends QuranResponse
 
         // Now load juz surahs and add to the response.
         $ayats->loadAyahSurahsByJuz($juz->getId(), $this->offset, $this->limit);
+        
+        
+        // Here, surahs must be an array not a json object
         $j['surahs'] = $ayats->getResponse();
 
         $j['edition'] = (new EditionResponse($this->edition->getIdentifier()))->getResponse();


### PR DESCRIPTION
In line 117, the surahs must be a list, not a JSON object (List of surahs).
Why? because when you try to use the endpoint associated with Juz, you will have a lot of data models, the number of these data models is the size of surahs. So, by adjusting surahs to be a list, you will have one data model (Surah) and the problem will be solved.